### PR TITLE
build: Update GNOME runtime to 42

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-  "skip-arches": ["aarch64"]
-}

--- a/org.gnome.seahorse.Application.json
+++ b/org.gnome.seahorse.Application.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.seahorse.Application",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "seahorse",
     "finish-args": [


### PR DESCRIPTION
build: Update GNOME runtime to 42
feat: Add aarch64 support (or why it was removed?)
fix: Remove shared-modules (not used)