### PR TITLE
Allow talk to org.gnome.keyring.SystemPrompter for pinentry

### DIFF
--- a/org.gnome.seahorse.Application.json
+++ b/org.gnome.seahorse.Application.json
@@ -11,6 +11,7 @@
         "--filesystem=~/.ssh:create",
         "--filesystem=~/.gnupg:create",
         "--talk-name=org.freedesktop.secrets",
+        "--talk-name=org.gnome.keyring.SystemPrompter",
         "--share=network"
     ],
     "cleanup": [


### PR DESCRIPTION
Fix to allow the use of GNOME pinentry over D-Bus.

Should fix #8.