### PR TITLE
Allow xdg-pictures filesystem access

### DIFF
--- a/org.gnome.seahorse.Application.json
+++ b/org.gnome.seahorse.Application.json
@@ -10,7 +10,7 @@
         "--device=dri",
         "--filesystem=~/.ssh:create",
         "--filesystem=~/.gnupg:create",
-        "--filesystem=xdg-pictures",
+        "--filesystem=xdg-pictures:ro",
         "--talk-name=org.freedesktop.secrets",
         "--share=network"
     ],

--- a/org.gnome.seahorse.Application.json
+++ b/org.gnome.seahorse.Application.json
@@ -10,6 +10,7 @@
         "--device=dri",
         "--filesystem=~/.ssh:create",
         "--filesystem=~/.gnupg:create",
+        "--filesystem=xdg-pictures",
         "--talk-name=org.freedesktop.secrets",
         "--share=network"
     ],


### PR DESCRIPTION
This is needed to be able to add a photo to a GPG key, as the file picker does not use portals for some reason.