### PR TITLE
Bump runtime to 45

### DIFF
--- a/build-gpg2.4.patch
+++ b/build-gpg2.4.patch
@@ -1,0 +1,24 @@
+From 9260c74779be3d7a378db0671af862ffa3573d42 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 21 Dec 2022 20:58:26 +0800
+Subject: [PATCH] Allow building with GnuPG-2.4.x
+
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index e29b5322..23d0b54f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -26,7 +26,7 @@ endif
+ # Dependencies
+ min_glib_version = '2.66'
+ min_gcr_version = '3.38'
+-accepted_gpg_versions = [ '2.2.0', '2.3.0' ]
++accepted_gpg_versions = [ '2.2.0', '2.3.0', '2.4.0' ]
+ gpg_check_version = find_program('build-aux' / 'gpg_check_version.py')
+
+ glib_deps = [
+--
+GitLab

--- a/org.gnome.seahorse.Application.json
+++ b/org.gnome.seahorse.Application.json
@@ -100,6 +100,10 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/seahorse/43/seahorse-43.0.tar.xz",
                     "sha256": "5b1d1bfba74f3658227f3c82e296f330dd0fcd1ef4636b6a218228fee5ea832d"
+                },
+                {
+                    "type": "patch",
+                    "path": "build-gpg2.4.patch"
                 }
             ]
         }

--- a/org.gnome.seahorse.Application.json
+++ b/org.gnome.seahorse.Application.json
@@ -51,16 +51,6 @@
             ]
         },
         {
-            "name": "gpgme",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-1.18.0.tar.bz2",
-                    "sha256": "361d4eae47ce925dba0ea569af40e7b52c645c4ae2e65e5621bf1b6cdd8b0e9e"
-                }
-            ]
-        },
-        {
             "name": "openldap",
             "config-opts": [
                 "--disable-backends",
@@ -76,19 +66,6 @@
                     "type": "archive",
                     "url": "https://openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.4.tgz",
                     "sha256": "d51704e50178430c06cf3d8aa174da66badf559747a47d920bb54b2d4aa40991"
-                }
-            ]
-        },
-        {
-            "name": "libpwquality",
-            "config-opts": [
-                "--enable-python-bindings=no"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/libpwquality/libpwquality/releases/download/libpwquality-1.4.5/libpwquality-1.4.5.tar.bz2",
-                    "sha256": "6fcf18b75d305d99d04d2e42982ed5b787a081af2842220ed63287a2d6a10988"
                 }
             ]
         },

--- a/org.gnome.seahorse.Application.json
+++ b/org.gnome.seahorse.Application.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.seahorse.Application",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "seahorse",
     "finish-args": [


### PR DESCRIPTION
43 is EOL https://gitlab.gnome.org/GNOME/gnome-build-meta/-/commit/8fff01ce7dc7f2ae66ee0aaec361206895c4657f but 45 should be published to the stable channel soon
